### PR TITLE
Instrumented application-specific metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 WebIndex is an example [Apache Fluo][fluo] application that uses [Common Crawl][cc] web crawl data
 to index links to web pages in multiple ways. It has a simple UI to view the resulting indexes. If
-you are new to Fluo, you may want start with the[phrasecount][pc] application as the WebIndex
+you are new to Fluo, you may want start with the [phrasecount][pc] application as the WebIndex
 application is more complicated. For more information on how the WebIndex application works, view
 the [tables](docs/tables.md) and [code](docs/code-guide.md) documentation.
 
@@ -21,18 +21,36 @@ Next, on a machine where Java and Maven are installed, run the development serve
     cd webindex/
     ./bin/webindex dev
 
-This will build and start the development server which will log to the console. When you want to
-terminate the server, press `ctrl-c`.
+This will build and start the development server which will log to the console. This 'dev' command
+has several command line options which can be viewed by running with `-h`. When you want to
+terminate the server, press `CTRL-c`.
 
-The development server starts a MiniAccumuloCluster and runs MiniFluo on top of it.  It parses a
-CommonCrawl data file and creates a file at `data/1K-pages.txt` with 1000 pages that are loaded into
-MiniFluo. The pages are processed by Fluo which exports indexes to Accumulo. A web application is
-started at [http://localhost:4567](http://localhost:4567) that queries these indexes.
+The development server starts a MiniAccumuloCluster and runs MiniFluo on top of it. It parses a
+CommonCrawl data file and creates a file at `data/1000-pages.txt` with 1000 pages that are loaded
+into MiniFluo. The number of pages loaded can be changed to 5000 by using the command below:
+
+    ./bin/webindex dev --pages 5000
+
+The pages are processed by Fluo which exports indexes to Accumulo. The development server also
+starts a web application  at [http://localhost:4567](http://localhost:4567) that queries indexes in
+Accumulo.
 
 If you would like to run WebIndex on a cluster, follow the [install] instructions. 
 
+### Viewing metrics
+
+Metrics can be sent from the development server to InfluxDB and viewed in Grafana. You can either
+setup InfluxDB+Grafana on you own or use [Uno] command `uno setup metrics`. After a metrics server
+is started, start the development server the option `--metrics` to start sending metrics:
+
+    ./bin/webindex dev --metrics
+
+Fluo metrics can be viewed in Grafana.  To view application-specific metrics for Webindex, import
+the WebIndex Grafana dashboard located at `contrib/webindex-dashboard.json`.
+
 [fluo]: https://fluo.apache.org/
 [pc]: https://github.com/astralway/phrasecount
+[Uno]: https://github.com/astralway/uno
 [cc]: https://commoncrawl.org/
 [install]: docs/install.md
 [ti]: https://travis-ci.org/astralway/webindex.svg?branch=master

--- a/bin/webindex
+++ b/bin/webindex
@@ -56,7 +56,8 @@ case "$1" in
 dev)
   pkill -9 -f webindex-dev-server
   cd $WI_HOME
-  mvn -q compile -P webindex-dev-server -Dlog4j.configuration=file:$log4j_config
+  dev_args="${@:2}"
+  mvn -q compile -P webindex-dev-server -Dlog4j.configuration=file:$log4j_config -Dexec.args="$dev_args"
   ;;
 getpaths)
   mkdir -p $DATA_DIR

--- a/contrib/webindex-dashboard.json
+++ b/contrib/webindex-dashboard.json
@@ -1,0 +1,645 @@
+{
+  "id": null,
+  "title": "Webindex",
+  "originalTitle": "Webindex",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 3,
+          "interval": "30s",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "ingested / sec",
+              "fields": [
+                {
+                  "func": "sum",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "webindex_pages_ingested",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_pages_ingested\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "rawQuery": false,
+              "refId": "A",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ]
+            },
+            {
+              "alias": "changed / sec",
+              "fields": [
+                {
+                  "func": "sum",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "webindex_pages_changed",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_pages_changed\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "refId": "B",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ]
+            },
+            {
+              "refId": "C",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ],
+              "groupBy": [
+                {
+                  "type": "time",
+                  "interval": "auto"
+                }
+              ],
+              "fields": [
+                {
+                  "name": "value",
+                  "func": "sum"
+                }
+              ],
+              "measurement": "webindex_pages_exported",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_pages_exported\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "alias": "exported / sec"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Pages",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 8,
+          "interval": "30s",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "new / sec",
+              "fields": [
+                {
+                  "func": "sum",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "webindex_domains_new",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_domains_new\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "refId": "A",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ]
+            },
+            {
+              "alias": "changed / sec",
+              "fields": [
+                {
+                  "func": "sum",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "webindex_domains_changed",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_domains_changed\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "refId": "B",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ]
+            },
+            {
+              "refId": "C",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ],
+              "groupBy": [
+                {
+                  "type": "time",
+                  "interval": "auto"
+                }
+              ],
+              "fields": [
+                {
+                  "name": "value",
+                  "func": "sum"
+                }
+              ],
+              "measurement": "webindex_domains_exported",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_domains_exported\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "alias": "exported / sec"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Domains",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        }
+      ],
+      "title": "Row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 6,
+          "interval": "30s",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "ingested / sec",
+              "fields": [
+                {
+                  "func": "sum",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "webindex_links_ingested",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_links_ingested\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "refId": "A",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ]
+            },
+            {
+              "alias": "new / sec",
+              "fields": [
+                {
+                  "func": "sum",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "webindex_links_new",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_links_new\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "refId": "B",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ]
+            },
+            {
+              "alias": "changed / sec",
+              "fields": [
+                {
+                  "func": "sum",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "webindex_links_changed",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_links_changed\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "refId": "C",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ]
+            },
+            {
+              "refId": "D",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ],
+              "groupBy": [
+                {
+                  "type": "time",
+                  "interval": "auto"
+                }
+              ],
+              "fields": [
+                {
+                  "name": "value",
+                  "func": "sum"
+                }
+              ],
+              "measurement": "webindex_links_exported",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_links_exported\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "alias": "exported / sec"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Links",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 9,
+          "interval": "30s",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "pages / sec",
+              "fields": [
+                {
+                  "func": "sum",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "webindex_pages_exported",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_pages_exported\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "refId": "A",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ]
+            },
+            {
+              "alias": "links / sec",
+              "fields": [
+                {
+                  "func": "sum",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "webindex_links_exported",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_links_exported\" WHERE \"field\" = 'm1_rate' AND $timeFilter GROUP BY time($interval)",
+              "refId": "B",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m1_rate"
+                }
+              ]
+            },
+            {
+              "alias": "domains / sec",
+              "fields": [
+                {
+                  "func": "sum",
+                  "name": "value"
+                }
+              ],
+              "groupBy": [
+                {
+                  "interval": "auto",
+                  "type": "time"
+                }
+              ],
+              "measurement": "webindex_domains_exported",
+              "query": "SELECT sum(\"value\") AS \"value\" FROM \"webindex_domains_exported\" WHERE \"field\" = 'm5_rate' AND $timeFilter GROUP BY time($interval)",
+              "refId": "C",
+              "tags": [
+                {
+                  "key": "field",
+                  "operator": "=",
+                  "value": "m5_rate"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Exported Comparison",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        }
+      ],
+      "title": "New row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [],
+      "title": "New row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [],
+      "title": "New row"
+    }
+  ],
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "refresh": "30s",
+  "schemaVersion": 7,
+  "version": 1,
+  "links": []
+}

--- a/modules/integration/src/main/java/webindex/integration/DevServerOpts.java
+++ b/modules/integration/src/main/java/webindex/integration/DevServerOpts.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Webindex authors (see AUTHORS)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package webindex.integration;
+
+import com.beust.jcommander.Parameter;
+
+public class DevServerOpts {
+
+  @Parameter(names = {"--metrics", "-m"}, description = "Enables sending metrics to localhost:3000")
+  boolean metrics = false;
+
+  @Parameter(names = {"--pages", "-p"}, description = "Number of pages to load")
+  int numPages = 1000;
+
+  @Parameter(names = {"--templateDir", "-t"}, description = "Specifies template directory")
+  String templateDir = "modules/ui/src/main/resources/spark/template/freemarker";
+
+  @Parameter(names = {"--help", "-h"}, description = "Prints usage", help = true)
+  boolean help;
+}

--- a/modules/integration/src/test/java/webindex/integration/DevServerIT.java
+++ b/modules/integration/src/test/java/webindex/integration/DevServerIT.java
@@ -41,7 +41,8 @@ public class DevServerIT {
   @BeforeClass
   public static void init() throws Exception {
     tempPath = Files.createTempDirectory(Paths.get("target/"), "webindex-dev-");
-    devServer = new DevServer(Paths.get("src/test/resources/5-pages.txt"), 24567, null, tempPath);
+    Path dataPath = Paths.get("src/test/resources/5-pages.txt");
+    devServer = new DevServer(dataPath, 24567, null, tempPath, false);
     devServer.start();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@
           <configuration>
             <excludes>
               <exclude>README.md</exclude>
+              <exclude>contrib/webindex-dashboard.json</exclude>
               <exclude>docs/**.md</exclude>
               <exclude>conf/webindex-tests.txt</exclude>
               <exclude>src/test/resources/5-pages.txt</exclude>


### PR DESCRIPTION
* Created Grafana dashboard in contrib/ that can be used
  to view Webindex metrics
* Modified DevServer to keep MiniFluo running until stop() method
  is called
* DevServer now creates data directory in target/ rather than /tmp/
* 'dev' command accepts different command line options
* Improved dev server documentation in README.md